### PR TITLE
Adding sleep before switching PTT 

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/IcomRig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/IcomRig.java
@@ -56,8 +56,13 @@ public class IcomRig extends BaseRig {
 
             switch (getControlMode()) {
                 case ControlMode.CAT://以CIV指令
-                    getConnector().setPttOn(IcomRigConstant.setPTTState(ctrAddress, getCivAddress()
-                            , on ? IcomRigConstant.PTT_ON : IcomRigConstant.PTT_OFF));
+                    try{
+                        Thread.sleep(100);
+                        getConnector().setPttOn(IcomRigConstant.setPTTState(ctrAddress, getCivAddress()
+                                , on ? IcomRigConstant.PTT_ON : IcomRigConstant.PTT_OFF));
+                    } catch (Exception e) {
+                        Log.e(TAG, e.getMessage());
+                    }
                     break;
                 //case ControlMode.NETWORK:
                 case ControlMode.RTS:


### PR DESCRIPTION
Trying to fix the issue that was raised here https://github.com/N0BOY/FT8CN/issues/60
Added a delay for 100ms after sending Civ data and before turning PTT on/off. 

I don't know exactly why this issue happens, but it resolves on my machine.