### PR TITLE
Set Elecraft to data mode instead of sideband

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/ElecraftRig.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/ElecraftRig.java
@@ -101,7 +101,7 @@ public class ElecraftRig extends BaseRig {
     @Override
     public void setUsbModeToRig() {
         if (getConnector() != null) {
-            getConnector().sendData(ElecraftRigConstant.setOperationUSBMode());
+            getConnector().sendData(ElecraftRigConstant.setOperationDataMode());
         }
     }
 

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/ElecraftRigConstant.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/rigs/ElecraftRigConstant.java
@@ -21,6 +21,8 @@ public class ElecraftRigConstant {
     private static final String PTT_ON = "TX;";
     private static final String PTT_OFF = "RX;";
     private static final String USB_MODE = "MD2;";
+    private static final String DATA_MODE = "MD6;";
+    private static final String DATA_R_MODE = "MD7;";
     private static final String READ_FREQ = "FA;";
     private static final String READ_SWR = "SWR;";
 
@@ -65,6 +67,10 @@ public class ElecraftRigConstant {
 
     public static byte[] setOperationUSBMode() {
         return USB_MODE.getBytes();
+    }
+
+    public static byte[] setOperationDataMode() {
+        return DATA_MODE.getBytes();
     }
 
 


### PR DESCRIPTION
Elecraft products offer a data mode that is different from sideband. Data mode removes ssb processing settings and remembers a different bandwidth setting. When using data modes, this should be selected.

The previous control code of MD2 was setting the radios to USB. MD6 sets the radios to data mode (and for good measure we define DATA_R for reverse sideband although it does not get used).

The MD6 setting is definitely the correct one for the K[x]3 and KX2 products. From reading the K2 manual and programming manual it seems to be correct for the K2 as well.

I'm not able to build the project. I'm glad to test an APK on the KX3 if a test build could be made for me.